### PR TITLE
Route OpenSearch Dashboards via subdomain to support multiple projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ After installation, make sure to commit the `.ddev` directory to version control
 | Command | Description |
 | ------- | ----------- |
 | `ddev launch :9201` | Open OpenSearch in your browser |
-| `ddev launch :5602` | Open OpenSearch Dashboards in your browser |
+| Open `https://<projectname>-opensearch.ddev.site` | Open OpenSearch Dashboards in your browser |
 | `ddev describe` | View service status and used ports for OpenSearch |
 | `ddev logs -s opensearch` | View OpenSearch logs |
 | `ddev logs -s opensearch-dashboards` | View OpenSearch Dashboards logs |

--- a/docker-compose.opensearch.yaml
+++ b/docker-compose.opensearch.yaml
@@ -41,12 +41,13 @@ services:
   opensearch-dashboards:
     image: opensearchproject/opensearch-dashboards:${OPENSEARCH_DASHBOARDS_TAG:-latest}
     container_name: 'ddev-${DDEV_SITENAME}-opensearch-dashboards'
+    hostname: ${DDEV_SITENAME}-opensearch-dashboards
     environment:
-      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - VIRTUAL_HOST=${DDEV_SITENAME}-opensearch.${DDEV_TLD:-ddev.site}
       - OPENSEARCH_HOSTS=http://ddev-${DDEV_PROJECT}-opensearch:9200
       - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true" # disables security plugin
-      - HTTP_EXPOSE=5601:5601
-      - HTTPS_EXPOSE=5602:5601
+      - HTTP_EXPOSE=80:5601
+      - HTTPS_EXPOSE=443:5601
     expose:
       - 5601
     labels:

--- a/install.yaml
+++ b/install.yaml
@@ -1,5 +1,8 @@
 name: ddev-opensearch
 
+yaml_read_files:
+  projectConfig: .ddev/config.yaml
+
 project_files:
   - docker-compose.opensearch.yaml
 
@@ -16,5 +19,17 @@ pre_install_actions:
         exit 2
       fi
     fi
+
+post_install_actions:
+  - |
+    #ddev-nodisplay
+    #ddev-description:Registering OpenSearch Dashboards hostname
+    printf '#ddev-generated\nadditional_hostnames:\n  - {{ .projectConfig.name }}-opensearch\n' > "${DDEV_APPROOT}/.ddev/config.opensearch-dashboards.yaml"
+
+removal_actions:
+  - |
+    #ddev-nodisplay
+    #ddev-description:Removing OpenSearch Dashboards hostname configuration
+    rm -f "${DDEV_APPROOT}/.ddev/config.opensearch-dashboards.yaml"
 
 ddev_version_constraint: '>= v1.24.3'

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -48,12 +48,12 @@ health_checks() {
   assert_success
   assert_output --partial "The OpenSearch Project"
 
-  run curl -sfI https://${PROJNAME}.ddev.site:5602
+  run curl -sfI https://${PROJNAME}-opensearch.ddev.site
   assert_success
   assert_output --partial "HTTP/2 302"
   assert_output --partial "location: /app/home"
 
-  run curl -sfL https://${PROJNAME}.ddev.site:5602
+  run curl -sfL https://${PROJNAME}-opensearch.ddev.site
   assert_success
   assert_output --partial "OpenSearch Dashboards"
 


### PR DESCRIPTION
## The Issue

When multiple DDEV projects use the `ddev-opensearch` addon simultaneously, the OpenSearch Dashboards service can cause port conflicts on port 5601/5602 since all projects compete for the same router ports.

## How This PR Solves The Issue

- Replaced port-based routing (`HTTP_EXPOSE=5601:5601` / `HTTPS_EXPOSE=5602:5601`) with subdomain-based routing on standard ports (`HTTP_EXPOSE=80:5601` / `HTTPS_EXPOSE=443:5601`)
- Each project gets a unique hostname: `<projectname>-opensearch.ddev.site`
- The addon now registers this hostname via a `config.opensearch-dashboards.yaml` overlay using `additional_hostnames`, so DDEV manages DNS/hosts resolution automatically
- Added `removal_actions` to clean up the hostname config when the addon is removed

**Before:** `https://myproject.ddev.site:5602`
**After:** `https://myproject-opensearch.ddev.site`

## Manual Testing Instructions
`
1. Verify https://<projectname>-opensearch.ddev.site opens OpenSearch Dashboards
2. Start a second DDEV project with the same addon and verify both dashboards are accessible without port conflicts
3. Run ddev add-on remove ddev-opensearch and verify .ddev/config.opensearch-dashboards.yaml is removed

Automated Testing Overview

Updated existing tests in tests/test.bats to use the new subdomain URL (https://${PROJNAME}-opensearch.ddev.site) instead of the old port-based URL (https://${PROJNAME}.ddev.site:5602).

Release/Deployment Notes

Breaking change: The dashboards URL changes from https://<project>.ddev.site:5602 to https://<project>-opensearch.ddev.site. Users with bookmarks or scripts referencing the old port-based URL will need to update them.
```